### PR TITLE
Fix the return value in the sort() function to follow the standard

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = function() {
         return false;
       }
     });
-    itemsFiltered.sort(function(a, b) { return a[Object.keys(a)[0]] < b[Object.keys(b)[0]]; });
+    itemsFiltered.sort(function(a, b) { return a[Object.keys(a)[0]] < b[Object.keys(b)[0]] ? 1 : -1 });
 
     for(item in itemsFiltered) {
       if(itemsFiltered.hasOwnProperty(item)) {


### PR DESCRIPTION
The sort() function that's called after filtering the items was returning a boolean instead of `1`, `-1` or `0` as it is specified in the [standard](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort). It happens to work in some versions of NodeJS and Firefox but not Chrome (the versions I tried at least).